### PR TITLE
Update utils.py

### DIFF
--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -198,10 +198,12 @@ def unpack_inline_message_id(inline_message_id: str) -> "raw.base.InputBotInline
         )
 
 
-MIN_CHANNEL_ID = -1002147483647
+# MIN_CHANNEL_ID_OLD = -1002147483647
+# MIN_CHAT_ID_OLD = -2147483647
+# MAX_USER_ID_OLD = 2147483647
+MIN_CHANNEL_ID = -1007852516352
 MAX_CHANNEL_ID = -1000000000000
-MIN_CHAT_ID = -2147483647
-MAX_USER_ID_OLD = 2147483647
+MIN_CHAT_ID = -999999999999
 MAX_USER_ID = 999999999999
 
 
@@ -232,18 +234,16 @@ def get_peer_id(peer: raw.base.Peer) -> int:
 
     raise ValueError(f"Peer type invalid: {peer}")
 
-# Edit
-# https://github.com/pyrogram/pyrogram/issues/1417
+
 def get_peer_type(peer_id: int) -> str:
-    print('get_peer_type call')
-    peer_id_str = str(peer_id)
-    
-    if not peer_id_str.startswith("-"):
+    if peer_id < 0:
+        if MIN_CHAT_ID <= peer_id:
+            return "chat"
+
+        if MIN_CHANNEL_ID <= peer_id < MAX_CHANNEL_ID:
+            return "channel"
+    elif 0 < peer_id <= MAX_USER_ID:
         return "user"
-    elif peer_id_str.startswith("-100"):
-        return "channel"
-    else:
-        return "chat"
 
     raise ValueError(f"Peer id invalid: {peer_id}")
 


### PR DESCRIPTION
 pyrogram: update MIN_CHANNEL_ID and MIN_CHAT_ID #1430 


Contribution Request: Update MIN_CHANNEL_ID and MIN_CHAT_ID in Pyrogram Title: Update MIN_CHANNEL_ID and MIN_CHAT_ID to Fix "Peer id invalid" Error Description

This contribution request proposes an update to the MIN_CHANNEL_ID and MIN_CHAT_ID values in Pyrogram. The current values are causing a "Peer id invalid" error in some scenarios. This update changes the MIN_CHANNEL_ID to -1007852516352 and the MIN_CHAT_ID to -999999999999 to address this issue. Changes

    Old Value: MIN_CHANNEL_ID = -1002147483647
    New Value: MIN_CHANNEL_ID = -1007852516352
    Old Value: MIN_CHAT_ID = -2147483647
    New Value: MIN_CHAT_ID = -999999999999

Reason for Change

The existing MIN_CHANNEL_ID and MIN_CHAT_ID values are no longer valid in certain cases, leading to the "Peer id invalid" error. By updating the values, we aim to resolve this error and ensure that Pyrogram can handle channel and chat IDs correctly. Code Update

The change will be made in the relevant Pyrogram file where MIN_CHANNEL_ID and MIN_CHAT_ID are defined.

# Current values
MIN_CHANNEL_ID = -1002147483647
MIN_CHAT_ID = -2147483647

# Updated values
MIN_CHANNEL_ID = -1007852516352
MIN_CHAT_ID = -999999999999

Testing

To verify this change, tests will be conducted to ensure that channel and chat IDs are processed correctly without causing the "Peer id invalid" error. Specific test cases will include:

    Creating a channel with an ID greater than -1007852516352 and verifying successful handling.
    Creating a chat with an ID greater than -999999999999 and verifying successful handling.
    Handling channel and chat IDs close to the boundary values to ensure no off-by-one errors or similar issues.
    General regression testing to ensure no other functionality is impacted.

Impact

This update is expected to fix the "Peer id invalid" error without introducing any breaking changes. All existing functionalities should remain intact, with improved reliability in handling channel and chat IDs. Acknowledgements

Special thanks to the users and developers who identified and reported the "Peer id invalid" error and contributed to the discussion around the solution. Additional Notes

Please review and merge this contribution to improve the robustness of Pyrogram in handling Telegram channel and chat IDs. If there are any questions or further suggestions, I am available to discuss them.

Thank you for your time and consideration.

Submitted by: ebiza